### PR TITLE
Added: parameters for customizing target machine's spec (cpu & memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ docker-machine create --driver ddcloud \
 	--ddcloud-networkdomain 'my-docker-domain' \
 	--ddcloud-vlan 'my-docker-vlan' \
 	--ddcloud-ssh-key ~/.ssh/id_rsa \
+	--ddcloud-memorygb 8 \
+	--ddcloud-cpucount 4 \
+	--ddcloud-corespersocket 4 \
 	--ddcloud-ssh-bootstrap-password 'throw-away-password' \
 	mydockermachine
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Environment: `MCP_REGION`.
 * `ddcloud-networkdomain` - The name of the target CloudControl network domain.
 * `ddcloud-datacenter` - The name of the CloudControl datacenter (e.g. NA1, AU9) in which the network domain is located.
 * `ddcloud-vlan` - The name of the target CloudControl VLAN.
+* `ddcloud-memorygb` - The amount of RAM in GB for the target machine. (Default 4GB)
+* `ddcloud-cpucount` - The amount of CPUs for the target machine. (Default: 2)
+* `ddcloud-corespersocket` - The amount of cores per socket for the target machine. (Default: 2)
 * `ddcloud-image-name` - The name of the image used to create the target machine.
 Additionally, the OS must be a Linux distribution supported by docker-machine (Ubuntu 12.04 and above are supported, but RedHat 6 and 7 are not supported due to iptables configuration issues).
 * `ddcloud-ssh-user` - The SSH username to use.

--- a/client.go
+++ b/client.go
@@ -248,10 +248,6 @@ func (driver *Driver) resolveImage() error {
 		)
 	}
 
-	driver.ImageID = image.GetID()
-	driver.ImageType = image.GetType()
-	driver.ImageOSType = image.GetOS().ID
-
 	return nil
 }
 
@@ -332,6 +328,12 @@ func (driver *Driver) buildDeploymentConfiguration() (deploymentConfiguration co
 
 		Start: true,
 	}
+
+	// Customise memory and / or CPU (if required).
+	deploymentConfiguration.MemoryGB = driver.MemoryGB
+	deploymentConfiguration.CPU.Count = driver.CPUCount
+	deploymentConfiguration.CPU.CoresPerSocket = driver.CoresPerSocket
+
 	image.ApplyTo(&deploymentConfiguration)
 
 	return

--- a/client.go
+++ b/client.go
@@ -248,6 +248,10 @@ func (driver *Driver) resolveImage() error {
 		)
 	}
 
+	driver.ImageID = image.GetID()
+	driver.ImageType = image.GetType()
+	driver.ImageOSType = image.GetOS().ID
+
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -333,12 +333,12 @@ func (driver *Driver) buildDeploymentConfiguration() (deploymentConfiguration co
 		Start: true,
 	}
 
+	image.ApplyTo(&deploymentConfiguration)
+
 	// Customise memory and / or CPU (if required).
 	deploymentConfiguration.MemoryGB = driver.MemoryGB
 	deploymentConfiguration.CPU.Count = driver.CPUCount
 	deploymentConfiguration.CPU.CoresPerSocket = driver.CoresPerSocket
-
-	image.ApplyTo(&deploymentConfiguration)
 
 	return
 }

--- a/driver.go
+++ b/driver.go
@@ -102,6 +102,13 @@ type Driver struct {
 	// The client's public (external) IP address.
 	ClientPublicIPAddress string
 
+	// The amount of RAM in GB for the target machine
+	MemoryGB int
+	// The amount of CPUs for the target machine
+	CPUCount int
+	// The amount of cores per socket for the target machine.
+	CoresPerSocket int
+
 	// The CloudControl API client.
 	client *compute.Client
 }
@@ -201,6 +208,21 @@ func (driver *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:  "ddcloud-use-private-ip",
 			Usage: "Don't create NAT and firewall rules for target server (you will need to be connected to the VPN for your target data centre). Default: false",
 		},
+		mcnflag.IntFlag{
+			Name:   "ddcloud-memorygb",
+			Usage:  "The amount of RAM in GB for the target machine. Default: 4",
+			Value:  4,
+		},
+		mcnflag.IntFlag{
+			Name:   "ddcloud-cpucount",
+			Usage:  "The amount of CPUs for the target machine. Default: 2",
+			Value:  2,
+		},
+		mcnflag.IntFlag{
+			Name:   "ddcloud-corespersocket",
+			Usage:  "The amount of cores per socket for the target machine. Default: 2",
+			Value:  2,
+		},
 	}
 }
 
@@ -233,6 +255,10 @@ func (driver *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	driver.CreateDockerFirewallRule = flags.Bool("ddcloud-create-ssh-firewall-rule")
 	driver.ClientPublicIPAddress = flags.String("ddcloud-client-public-ip")
 	driver.UsePrivateIP = flags.Bool("ddcloud-use-private-ip")
+
+	driver.MemoryGB = flags.Int("ddcloud-memorygb")
+	driver.CPUCount = flags.Int("ddcloud-cpucount")
+	driver.CoresPerSocket = flags.Int("ddcloud-corespersocket")
 
 	log.Debugf("docker-machine-driver-ddcloud %s", DriverVersion)
 


### PR DESCRIPTION
added support for:
* `ddcloud-memorygb` - The amount of RAM in GB for the target machine. (Default 4GB)
* `ddcloud-cpucount` - The amount of CPUs for the target machine. (Default: 2)
* `ddcloud-corespersocket` - The amount of cores per socket for the target machine. (Default: 2)